### PR TITLE
Add support for cross-platform builds.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,6 @@ repos:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.7
-    hooks:
-      - id: docformatter
-        args: [--in-place, --black]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.12
     hooks:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you are in the cross-platform environment, and you need to temporarily conver
     (x-venv) $ XBUILD_ENV=off python -c "import sys; print(sys.platform)"
     darwin
 
-If you have an active cross-platform virtual environment, you can run `xbuild` without providing the `--sysconfig` variable. The configuration of your existing cross virtual environment will copied into the isolated environment for the build.
+If you have an active cross-platform virtual environment, you can run `xbuild` without providing the `--sysconfig` variable. The configuration of your existing cross virtual environment will copied into the isolated environment for the build. Alternatively, you can also use the `--no-isolation` flag to disable the creation of a isolated cross-platform build environment. This will use your existing cross-platform environment as the build environment.
 
 ## How this works
 

--- a/README.md
+++ b/README.md
@@ -14,18 +14,74 @@
 
 ## Usage
 
-### Creating a cross virtual environment
+To use xbuild, you need:
+* an install of Python for the platform where you will be performing the build (e.g., macOS, Linux or Windows)
+* a distribution of Python that has been compiled for your target platform (e.g., Android, Emscripten or iOS)
 
-To create a cross virtual environment, you will need a distribution of Python that has been compiled for Android, Emscripten or iOS. Create a virtual environment for your build platform (i.e., the platform where you will be compiling), then use the `xvenv` script to convert that virtual environment in to a cross environment.
+
+### Build a package
+
+Create a virtual environment for your build platform (i.e., the platform where you will be compiling), and install `xbuild`:
 
     $ python3 -m venv venv
     $ source venv/bin/activate
-    (venv) $ pip install xbuild
+    (venv) $ python -m pip install xbuild
+
+You can then run `xbuild` from the root directory of the project you want to build. You *must* pass in the `--sysconfig` argument, providing the path to the `sysconfig_vars` JSON file for the target platform, or the equivalent `sysconfigdata` python configuration.
+
+    (venv) $ python -m xbuild --sysconfig path/to/_sysconfig_vars__...json
+
+This will create an isolated cross-platform virtual environment, and trigger a PEP 517 build in that environment. Any build `requires` will be installed *for the build platform*. For example, if you're running on macOS, building for an ARM64 iPhone simulator, and your project lists `ninja` as a requirement, the *macOS* version of ninja will be installed. This ensures that the binary will be executable during the build.
+
+If, for some reason, you require the *iOS* version of a build requirement to be installed, you can specify `target-requires` in your `build-system` table. For example, to add the iOS version of "target-tool" to your isolated cross-build environment, you might use:
+
+    [build-system]
+    requires = ["setuptools"]
+    target-requires = ["target-tool"]
+    build_backenmd = "setuptools.build_meta"
+
+In order for a cross-build to succeed, your environment must be configured appropriately for the platform you're targeting.
+
+#### Android
+
+To build an Android wheel, you must:
+
+* Have Android Studio or the Android Command-line Tools installed
+* Have `ANDROID_HOME` configured in your environment
+* Have a Java SDK installed
+* Have `JAVA_HOME` defined in your environment
+
+#### iOS
+
+You must have Xcode installed, with the iOS SDK added.
+
+It is also strongly advised that you:
+* Add the path to the iOS binary shims to your path. These are provided in the `Python.xcframework/ios-arm64/bin` and `Python.xcframework/ios-arm64_x86_64-simulator/bin` folder for the iOS support package that you have downloaded.
+* Clear your path of any other dependencies. It is very easy for macOS ARM64 binaries from Homebrew and other sources to leak into iOS builds if they are present on the path; the safest approach is to set your path so it only contains:
+  - The path for the Python binary (ideally, your virtual environment's `bin` directory)
+  - `/usr/bin`
+  - `/bin`
+  - `/usr/sbin`
+  - `/sbin`
+  - `/Library/Apple/usr/bin`
+
+#### Emscripten
+
+TODO
+
+### Creating a cross virtual environment
+
+To explicitly create a cross-platform virtual environment, start by creating a virtual environment for your build platform (i.e., the platform where you will be compiling), then use the `xvenv` script to convert that virtual environment in to a cross environment.
+
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    (venv) $ python -m pip install xbuild
     (venv) $ python -m venv x-venv
-    (venv) $ xvenv --sysconfig path/to/_sysconfig_vars__...json x-venv
+    (venv) $ python -m xvenv --sysconfig path/to/_sysconfig_vars__...json x-venv
 
-You can then activate the cross virtual environment. For example, if `x-venv` was constructed using an iOS simulator sysconfig vars file (`_sysconfig_vars__ios_arm64-iphonesimulator.json`), you would see output like:
+You can then deactivate the environment that was used to create the cross-platform environment, and activate the cross-platform virtual environment. For example, if `x-venv` was constructed using an iOS simulator sysconfig vars file (`_sysconfig_vars__ios_arm64-iphonesimulator.json`), you would see output like:
 
+    (venv) $ deactivate
     $ source x-venv/bin/activate
     (x-venv) $ python -c "import sys; print(sys.platform)"
     ios
@@ -36,13 +92,15 @@ This should now print the platform identifier for the target platform, not your 
 
 You can also configure xvenv with a `_sysconfigdata` Python file (e.g., `_sysconfigdata__ios_arm64-iphonesimulator.py`), instead of the `_sysconfig_var` JSON file. You'll have to use `_sysconfigdata` if you're on Python 3.13 (as the JSON format was only introduced in Python 3.14)
 
-If you are in the cross environment, and you need to temporarily convert it back to the build platform, you can do so with the `XBUILD_ENV` environment variable. For example, if `x-venv` is an iOS cross environment:
+If you are in the cross-platform environment, and you need to temporarily convert it back to the build platform, you can do so with the `XBUILD_ENV` environment variable. For example, if `x-venv` is an iOS cross-platform environment:
 
     $ source x-venv/bin/activate
     (x-venv) $ python -c "import sys; print(sys.platform)"
     ios
     (x-venv) $ XBUILD_ENV=off python -c "import sys; print(sys.platform)"
     darwin
+
+If you have an active cross-platform virtual environment, you can run `xbuild` without providing the `--sysconfig` variable. The configuration of your existing cross virtual environment will copied into the isolated environment for the build.
 
 ## How this works
 

--- a/src/xbuild/_builder.py
+++ b/src/xbuild/_builder.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from build import _builder, _ctx
+from build._builder import ProjectBuilder, _parse_build_system_table
+from build._types import ConfigSettings, Distribution
+
+
+###########################################################################
+# Patch `build._builder._parse_xbuild_system_table` so that it doesn't break
+# in the presence of the `target-requires` setting.
+###########################################################################
+def parse_xbuild_system_table(pyproject_toml: Mapping[str, Any]) -> Mapping[str, Any]:
+    target_requires = pyproject_toml.get("build-system", {}).pop("target-requires", [])
+
+    build_system_table = _parse_build_system_table(pyproject_toml)
+
+    build_system_table["target-requires"] = target_requires
+
+    return build_system_table
+
+
+_builder._parse_build_system_table = parse_xbuild_system_table
+
+
+###########################################################################
+# A ProjectXBuilder that understands how to handle target requirements
+############################################################################
+class ProjectXBuilder(ProjectBuilder):
+    @property
+    def build_system_target_requires(self) -> set[str]:
+        """The dependencies defined in the ``pyproject.toml``'s
+        ``build-system.target-requires`` field.
+        """
+        return set(self._build_system["target-requires"])
+
+    def get_target_requires_for_build(
+        self,
+        distribution: Distribution,
+        config_settings: ConfigSettings | None = None,
+    ) -> set[str]:
+        """Return the dependencies defined by the backend in addition to
+        :attr:`build_system_requires` for a given distribution.
+
+        :param distribution: Distribution to get the dependencies of
+            (``sdist`` or ``wheel``)
+        :param config_settings: Config settings for the build backend
+        """
+        _ctx.log(f"Getting target build dependencies for {distribution}...")
+        hook_name = f"get_target_requires_for_build_{distribution}"
+        try:
+            get_requires = getattr(self._hook, hook_name)
+
+            with self._handle_backend(hook_name):
+                return set(get_requires(config_settings))
+        except AttributeError:
+            # For now, most build backends won't implement
+            # get_target_requires_for_build_wheel
+            pass

--- a/src/xbuild/env.py
+++ b/src/xbuild/env.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import sysconfig
+from collections.abc import Collection
+from contextlib import contextmanager
+from pathlib import Path
+
+from build import _ctx
+from build import env as build_env
+from build.env import DefaultIsolatedEnv, _PipBackend
+
+
+###########################################################################
+# Patch `build.env._PipBackend` to disable the cross-build environment
+# for installs if the install is not for the target.
+###########################################################################
+@contextmanager
+def install_environment(os, for_target):
+    """A context manager that temporarily configures the XBUILD_ENV variable.
+
+    :param for_target: If False, disables any active cross-venv by setting
+        XBUILD_ENV=off in the environment.
+    """
+    old_xbuild_env = os.environ.get("XBUILD_ENV", None)
+    if not for_target:
+        os.environ["XBUILD_ENV"] = "off"
+
+    yield
+    if not for_target:
+        if old_xbuild_env is None:
+            del os.environ["XBUILD_ENV"]
+        else:
+            os.environ["XBUILD_ENV"] = old_xbuild_env
+
+
+class _XPipBackend(_PipBackend):
+    def install_requirements(
+        self,
+        requirements: Collection[str],
+        for_target: bool = True,
+    ) -> None:
+        with install_environment(os, for_target=for_target):
+            super().install_requirements(requirements)
+
+
+build_env._PipBackend = _XPipBackend
+
+
+###########################################################################
+# Add an XBuild isolated environment that can handle cross-platform
+# installs, and passes
+###########################################################################
+class XBuildIsolatedEnv(DefaultIsolatedEnv):
+    def __init__(self, *, installer):
+        if installer == "uv":
+            raise RuntimeError("Can't support uv (for now)")
+
+        super().__init__()
+
+    def __enter__(self) -> XBuildIsolatedEnv:
+        super().__enter__()
+
+        # Copy any _cross_*.pth or _cross_*.py file, plus the cross-platform
+        # sysconfig data to the new environment.
+        data_name = sysconfig._get_sysconfigdata_name()
+        if sys.version_info < (3, 14):
+            vars_files = []
+        else:
+            vars_files = [sysconfig._get_json_data_name()]
+
+        multiarch = sys.implementation._multiarch.replace("-", "_")
+        SRC_SITE_PACKAGES = Path(sysconfig.get_path("platlib"))
+        for filename in [
+            "_cross_venv.pth",
+            f"_cross_{sys.platform}_{multiarch}.py",
+            f"{data_name}.py",
+        ] + vars_files:
+            src = SRC_SITE_PACKAGES / filename
+            target = Path(self._path) / src.relative_to(
+                SRC_SITE_PACKAGES.parent.parent.parent
+            )
+            if not target.exists():
+                shutil.copy(src, target)
+
+        return self
+
+    def install(self, requirements: Collection[str], for_target=True) -> None:
+        """Install packages from PEP 508 requirements in the isolated build environment.
+
+        :param requirements: PEP 508 requirement specification to install
+        :param for_target: Should the the cross build environment be active? True by
+            default; if False, `XBUILD_ENV=off` will be used to install build platform
+            binaries, rather than target platform binaries,
+        """
+        if not requirements:
+            return
+
+        for_loc = "target platform" if for_target else "build platform"
+        _ctx.log(
+            f"Installing packages for {for_loc} in isolated environment:\n"
+            + "\n".join(f"- {r}" for r in sorted(requirements))
+        )
+        self._env_backend.install_requirements(requirements, for_target=for_target)

--- a/src/xvenv/__main__.py
+++ b/src/xvenv/__main__.py
@@ -82,7 +82,7 @@ def entrypoint() -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(sys.argv[1:], "python -m build")
+    main(sys.argv[1:], "python -m xvenv")
 
 __all__ = [
     "main",


### PR DESCRIPTION
With this PR, it is now possible to run `python -m xbuild`, and generate iOS/Android/Emscripten binary wheels.

By default, it will create an isolated virtual environment; `--sysconfig` must be provided as an additional argument to set up the target environment.

If executed in a active cross-platform environment, the `--sysconfig` argument is optional, with configuration being inherited from the calling cross-platform environment; or `--no-isolation` can be used to use the cross-platform environment as is.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
