### PR TITLE
Bump ruff-pre-commit from v0.13.0 to v0.13.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.13.1
     hooks:
       - id: ruff-format
       - id: ruff-check


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.13.0 to v0.13.1 and ran the update against the repo.