### PR TITLE
Add options to use build-details.json as input

### DIFF
--- a/src/xbuild/__main__.py
+++ b/src/xbuild/__main__.py
@@ -205,8 +205,10 @@ def main_parser() -> argparse.ArgumentParser:
         "--no-isolation",
         "-n",
         action="store_true",
-        help="disable building the project in an isolated virtual environment. "
-        "Build dependencies must be installed separately when this option is used",
+        help=(
+            "disable building the project in an isolated virtual environment. "
+            "Build dependencies must be installed separately when this option is used"
+        ),
     )
     env_group.add_argument(
         "--installer",
@@ -224,13 +226,13 @@ def main_parser() -> argparse.ArgumentParser:
         "--build-details",
         dest="build_details_path",
         type=Path,
-        help=("The path to a build-details.json file.",),
+        help="The path to a build-details.json file.",
     )
     config_group.add_argument(
         "--sysconfig",
         dest="sysconfigdata_path",
         type=Path,
-        help=("The path to a sysconfigdata python file.",),
+        help="The path to a sysconfigdata python file.",
     )
     config_group = parser.add_mutually_exclusive_group()
     config_group.add_argument(

--- a/src/xbuild/env.py
+++ b/src/xbuild/env.py
@@ -56,12 +56,13 @@ build_env._PipBackend = _XPipBackend
 # and can handle both build and target dependency installs.
 ###########################################################################
 class XBuildIsolatedEnv(DefaultIsolatedEnv):
-    def __init__(self, *, installer, sysconfig_path):
+    def __init__(self, *, installer, build_details_path, sysconfigdata_path):
         if installer == "uv":
             raise RuntimeError("Can't support uv (for now)")
 
         super().__init__()
-        self.sysconfig_path = sysconfig_path
+        self.build_details_path = build_details_path
+        self.sysconfigdata_path = sysconfigdata_path
 
     def __enter__(self) -> XBuildIsolatedEnv:
         super().__enter__()
@@ -73,13 +74,17 @@ class XBuildIsolatedEnv(DefaultIsolatedEnv):
         if not getattr(sys, "cross_compiling", False):
             # We're in a local environment.
             # Make the isolated environment a cross environment.
-            if self.sysconfig_path is None:
+            if self.build_details_path is None and self.sysconfigdata_path is None:
                 raise RuntimeError(
-                    "Must specify the location of target platform sysconfig data "
-                    "with --sysconfig"
+                    "Must specify the location of target platform build_details.json "
+                    "with --build-details, or sysconfigdata with --sysconfig"
                 )
 
-            convert_venv(Path(self._path), self.sysconfig_path)
+            convert_venv(
+                Path(self._path),
+                build_details_path=self.build_details_path,
+                sysconfigdata_path=self.sysconfigdata_path,
+            )
         else:
             # We're already in a cross environment.
             # Copy any _cross_*.pth or _cross_*.py file, plus the cross-platform

--- a/src/xvenv/__main__.py
+++ b/src/xvenv/__main__.py
@@ -36,11 +36,23 @@ def main_parser():
         default=0,
         help="increase verbosity",
     )
-    parser.add_argument(
-        "-s",
-        "--sysconfig",
-        help="The path to a sysconfig_vars JSON file or sysconfigdata Python file",
+
+    # Create mutually exclusive group for --build-details and --sysconfig
+    # One of these arguments must be provided
+    config_group = parser.add_mutually_exclusive_group(required=True)
+    config_group.add_argument(
+        "--build-details",
+        dest="build_details_path",
+        type=Path,
+        help=("The path to a build-details.json file.",),
     )
+    config_group.add_argument(
+        "--sysconfig",
+        dest="sysconfigdata_path",
+        type=Path,
+        help=("The path to a sysconfigdata python file.",),
+    )
+
     parser.add_argument(
         "venv",
         help="The location of a native virtual environment",
@@ -60,13 +72,22 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
     args = parser.parse_args(cli_args)
 
     venv_path = Path(args.venv).resolve()
-    sysconfig_path = Path(args.sysconfig).resolve()
+    build_details_path = (
+        Path(args.build_details_path).resolve() if args.build_details_path else None
+    )
+    sysconfigdata_path = (
+        Path(args.sysconfigdata_path).resolve() if args.sysconfigdata_path else None
+    )
 
     if not venv_path.exists():
         _error(f"Native virtual environment {venv_path} does not exist.")
     else:
         try:
-            description = convert_venv(venv_path, sysconfig_path)
+            description = convert_venv(
+                venv_path,
+                build_details_path=build_details_path,
+                sysconfigdata_path=sysconfigdata_path,
+            )
         except Exception as e:
             _error(e)
             sys.exit(1)

--- a/src/xvenv/__main__.py
+++ b/src/xvenv/__main__.py
@@ -44,13 +44,13 @@ def main_parser():
         "--build-details",
         dest="build_details_path",
         type=Path,
-        help=("The path to a build-details.json file.",),
+        help="The path to a build-details.json file.",
     )
     config_group.add_argument(
         "--sysconfig",
         dest="sysconfigdata_path",
         type=Path,
-        help=("The path to a sysconfigdata python file.",),
+        help="The path to a sysconfigdata python file.",
     )
 
     parser.add_argument(

--- a/src/xvenv/platforms/android.py
+++ b/src/xvenv/platforms/android.py
@@ -1,6 +1,16 @@
-def extend_context(context, sysconfig):
+def build_details_from_sysconfigdata(sysconfigdata):
+    # Reconstruct a build_details-alike structure from sysconfigdata.
+    arch, _, platform = sysconfigdata["MULTIARCH"].split("-")
+    min_api_level = sysconfigdata["ANDROID_API_LEVEL"]
+    build_details = {
+        "platform": f"{platform}-{min_api_level}-{arch}",
+    }
+    return build_details
+
+
+def extend_context(context, build_details):
     # Convert the API level into a release number
-    api_level = int(sysconfig["ANDROID_API_LEVEL"])
+    api_level = int(build_details["platform"].split("-")[1])
     if api_level >= 33:
         release = f"{api_level - 20}"
     elif api_level == 32:

--- a/src/xvenv/platforms/emscripten.py
+++ b/src/xvenv/platforms/emscripten.py
@@ -1,4 +1,12 @@
-def extend_context(context, sysconfig):
+def build_details_from_sysconfigdata(sysconfigdata):
+    # Reconstruct a build_details-alike structure from sysconfigdata.
+    build_details = {
+        "platform": "emscripten-4.0.12-wasm32",
+    }
+    return build_details
+
+
+def extend_context(context, build_details):
     emscripten_version = "4.0.12"
     context["release"] = emscripten_version
     context["platform_version"] = emscripten_version

--- a/src/xvenv/platforms/ios.py
+++ b/src/xvenv/platforms/ios.py
@@ -1,5 +1,16 @@
-def extend_context(context, sysconfig):
-    release = sysconfig["IPHONEOS_DEPLOYMENT_TARGET"]
+def build_details_from_sysconfigdata(sysconfigdata):
+    # Reconstruct a build_details-alike structure from sysconfigdata.
+    platform = sysconfigdata["MACHDEP"]
+    multiarch = sysconfigdata["MULTIARCH"]
+    ios_target = sysconfigdata["IPHONEOS_DEPLOYMENT_TARGET"]
+    build_details = {
+        "platform": f"{platform}-{ios_target}-{multiarch}",
+    }
+    return build_details
+
+
+def extend_context(context, build_details):
+    release = build_details["platform"].split("-")[1]
     is_simulator = context["sdk"] == "iphonesimulator"
 
     ######################################################################


### PR DESCRIPTION
At present, `xvenv` and `xbuild` accept `--sysconfig` as an argument; the sysconfig file would then be used to extract configuration data that would the be used to shape the cross platform configuration.

Following some discussions at the Python core team summit in September, this PR adds a `--build-details` option, allowing the use of a `build_details.json` file. The build-details file is a better source of normalised configuration information about a build.

~~Created as a draft; partially because there's more manual testing required - but also because I was hoping to use this as an opportunity to add an actual test suite.~~ Test suites will have to wait.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
