### PR TITLE
Bump codespell from v2.4.1 to v2.4.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: ruff-check
         args: [ --fix ]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     - id: codespell
       # remove toml extra once Python 3.10 is no longer supported


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.4.1 to v2.4.2 and ran the update against the repo.