### PR TITLE
Add zizmor pre-commit configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,19 @@ updates:
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -7,4 +7,6 @@ on:
 jobs:
   check-pr-template:
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@main
+    permissions:
+      contents: read
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,6 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
-        # Nothing in this job pushes, so the token doesn't need to be
-        # persisted in .git/config.
         persist-credentials: false
 
     - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash  # https://github.com/beeware/briefcase/pull/912
@@ -30,7 +33,7 @@ env:
 jobs:
   pre-commit:
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       pre-commit-source: "--group pre-commit"
 
@@ -41,7 +44,7 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+    uses: beeware/.github/.github/workflows/python-package-create.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       attest: ${{ inputs.attest-package }}
 
@@ -56,12 +59,15 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
+        # Nothing in this job pushes, so the token doesn't need to be
+        # persisted in .git/config.
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: "${{ matrix.python-version }}"
         allow-prereleases: true

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -11,8 +11,11 @@ jobs:
   add-to-project:
     name: Add issue to BeeWare project
     runs-on: ubuntu-latest
+    # The add-to-project action authenticates with BRUTUS_PAT_TOKEN, so the
+    # job's own GITHUB_TOKEN needs no permissions.
+    permissions: {}
     steps:
-      - uses: actions/add-to-project@v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/beeware/projects/1
           github-token: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       # This permission is required for trusted publishing.
       id-token: write
     steps:
-      - uses: dsaltares/fetch-gh-release-asset@1.1.2
+      - uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7  # 1.1.2
         with:
           version: tags/${{ github.event.release.tag_name }}
           file: ${{ github.event.repository.name }}.*
@@ -19,4 +19,4 @@ jobs:
           target: dist/
 
       - name: Publish release to production PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,18 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: CI
+    # The called workflow's package job needs id-token/attestations to
+    # create the provenance attestation.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/ci.yml
     with:
       attest-package: "true"
@@ -26,25 +35,30 @@ jobs:
           echo "VERSION=${GITHUB_REF_NAME#v}" | tee -a $GITHUB_ENV
 
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.x"
 
       - name: Get packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: Packages
           path: dist
 
       - name: Create release
-        uses: ncipollo/release-action@v1.21.0
-        with:
-          name: ${{ env.VERSION }}
-          draft: true
-          artifacts: dist/*
-          artifactErrorsFailBuild: true
+        # gh is provided by the runner, so a third-party release action isn't
+        # needed; gh fails the step if any artifact upload fails.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${VERSION}" \
+            --draft \
+            --verify-tag \
+            dist/*
 
       - name: Publish release to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,6 @@ jobs:
           path: dist
 
       - name: Create release
-        # gh is provided by the runner, so a third-party release action isn't
-        # needed; gh fails the step if any artifact upload fails.
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,7 @@ repos:
       # remove toml extra once Python 3.10 is no longer supported
       additional_dependencies: ['.[toml]']
       args: ["--skip=CODE_OF_CONDUCT.md"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.27.0
+    hooks:
+    - id: zizmor


### PR DESCRIPTION
Adds [zizmor](https://docs.zizmor.sh) to the pre-commit pipeline, as requested in #70, and fixes every finding it reports on the existing GitHub Actions configuration. Follows the approach of beeware/.github#378.

## Changes

- **`.pre-commit-config.yaml`**: add the `zizmor` hook (v1.27.0).
- **unpinned-uses**: every action and reusable-workflow reference is pinned to a full commit hash (`checkout` v7.0.0, `setup-python` v6.3.0, `download-artifact` v8.0.1, `add-to-project` v2.0.0, `fetch-gh-release-asset` 1.1.2, `gh-action-pypi-publish` release/v1 head, and `beeware/.github` pinned to current `main`, 741cc5a).
- **excessive-permissions**: explicit least-privilege `permissions:` on every workflow/job; `release.yml`'s `ci` job explicitly forwards `id-token: write` + `attestations: write` so package attestation keeps working; `new-issue.yml` gets `permissions: {}` since it authenticates with `BRUTUS_PAT_TOKEN`.
- **artipacked**: the CI checkout sets `persist-credentials: false`; nothing in that job pushes.
- **superfluous-actions**: release creation now uses the runner's `gh` CLI (`gh release create --draft --verify-tag dist/*`) instead of `ncipollo/release-action` — same draft release with artifacts, and the step still fails if an artifact upload fails. Happy to revert this piece if you'd rather keep the action.
- **dependabot-cooldown**: 7-day cooldown on all three ecosystems, matching beeware/.github#378.

`zizmor .github/` now reports **no findings**, and `pre-commit run --all-files` passes with the new hook.

Fixes #70
Fixes #69

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Fable 5 (Claude Code)