### PR TITLE
Create target venv automatically if it doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,13 @@ htmlcov/
 coverage.xml
 tests/integration/
 .integration-sources
-.tox
 Dockerfile
 
 # In-repo spaces for local testing
 local/
 temp/
+
+# Agent tooling
+.opencode
+.kilo
+docs/superpowers/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,15 @@ repos:
       - id: ruff-format
       - id: ruff-check
         args: [ --fix ]
+  - repo: https://github.com/rvben/rumdl-pre-commit
+    rev: v0.2.62
+    hooks:
+      - id: rumdl
+      - id: rumdl-fmt
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3
     hooks:
     - id: codespell
-      # remove toml extra once Python 3.10 is no longer supported
-      additional_dependencies: ['.[toml]']
       args: ["--skip=CODE_OF_CONDUCT.md"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+`xvenv` will now create the target virtual environment if it doesn't already exist, equivalent to running `python -m venv <location>` before conversion. Previously, `xvenv` required the target directory to already exist as a valid virtual environment.
+
 ## 0.0.1 (5 Sep 2025)
 
 Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## Unreleased
 
-`xvenv` will now create the target virtual environment if it doesn't already exist, equivalent to running `python -m venv <location>` before conversion. Previously, `xvenv` required the target directory to already exist as a valid virtual environment.
+* `xvenv` will now create the target virtual environment if it doesn't already exist, equivalent to running `python -m venv <location>` before conversion. Previously, `xvenv` required the target directory to already exist as a valid virtual environment.
+* `xvenv` and `xbuild` can now be configured using a `build-details.json` file, as an alternative to a `sysconfig_vars` JSON file or `sysconfigdata` Python file.
+
+## 0.2.0 (10 Sep 2025)
+
+* Added `xbuild`, a PEP 517 build frontend that triggers cross-platform builds using a cross-platform virtual environment created by `xvenv`. Build requirements are installed for the build platform by default, unless listed in a new `target-requires` key in `build-system`, in which case they're installed for the target platform.
 
 ## 0.0.1 (5 Sep 2025)
 
 Initial release.
 
-Includes `xvenv`, a tool for creating cross platform environments. This has undergone initial testing to verify it works for iOS, Android and Emscripten environments. The created environment is sufficient to trick `pip` into installing binaries for the target platform into the environment; and for tools like `wheel` to trigger builds with compiler invocations derived from `sysconfgdata`. This won't generally result in a *successful* build, as there will usually be other environmental requirements; but the a cross-platform build will be attempted.
+* Includes `xvenv`, a tool for creating cross platform environments. This has undergone initial testing to verify it works for iOS, Android and Emscripten environments. The created environment is sufficient to trick `pip` into installing binaries for the target platform into the environment; and for tools like `wheel` to trigger builds with compiler invocations derived from `sysconfgdata`. This won't generally result in a *successful* build, as there will usually be other environmental requirements; but the a cross-platform build will be attempted.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ To use xbuild, you need:
 * an install of Python for the platform where you will be performing the build (e.g., macOS, Linux or Windows)
 * a distribution of Python that has been compiled for your target platform (e.g., Android, Emscripten or iOS)
 
-
 ### Build a package
 
 Create a virtual environment for your build platform (i.e., the platform where you will be compiling), and install `xbuild`:
@@ -38,9 +37,9 @@ If, for some reason, you require the *iOS* version of a build requirement to be 
     [build-system]
     requires = ["setuptools"]
     target-requires = ["target-tool"]
-    build_backenmd = "setuptools.build_meta"
+    build-backend = "setuptools.build_meta"
 
-In order for a cross-build to succeed, your environment must be configured appropriately for the platform you're targeting.
+In order for a cross-build to succeed, your environment must be configured appropriately for the platform you're targeting. This means setting `PATH` and other environment variables appropriately.
 
 #### Android
 
@@ -56,7 +55,9 @@ To build an Android wheel, you must:
 You must have Xcode installed, with the iOS SDK added.
 
 It is also strongly advised that you:
+
 * Add the path to the iOS binary shims to your path. These are provided in the `Python.xcframework/ios-arm64/bin` and `Python.xcframework/ios-arm64_x86_64-simulator/bin` folder for the iOS support package that you have downloaded.
+
 * Clear your path of any other dependencies. It is very easy for macOS ARM64 binaries from Homebrew and other sources to leak into iOS builds if they are present on the path; the safest approach is to set your path so it only contains:
   - The path for the Python binary (ideally, your virtual environment's `bin` directory)
   - `/usr/bin`
@@ -71,13 +72,14 @@ TODO
 
 ### Creating a cross virtual environment
 
-To explicitly create a cross-platform virtual environment, start by creating a virtual environment for your build platform (i.e., the platform where you will be compiling), then use the `xvenv` script to convert that virtual environment in to a cross environment.
+To explicitly create a cross-platform virtual environment, start by creating a virtual environment for your build platform (i.e., the platform where you will be compiling), then use the `xvenv` script to convert a virtual environment in to a cross environment.
 
     $ python3 -m venv venv
     $ source venv/bin/activate
     (venv) $ python -m pip install xbuild
-    (venv) $ python -m venv x-venv
     (venv) $ python -m xvenv --sysconfig path/to/_sysconfig_vars__...json x-venv
+
+If `x-venv` doesn't already exist, `xvenv` will create it first (equivalent to running `python -m venv x-venv`), then convert it into a cross environment. If `x-venv` already exists, it will be converted into a cross-platform environment of type specified by `--sysconfig`.
 
 You can then deactivate the environment that was used to create the cross-platform environment, and activate the cross-platform virtual environment. For example, if `x-venv` was constructed using an iOS simulator sysconfig vars file (`_sysconfig_vars__ios_arm64-iphonesimulator.json`), you would see output like:
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,46 @@
 # xbuild
 
-[![Python Versions](https://img.shields.io/pypi/pyversions/xbuild.svg)](https://pypi.python.org/pypi/xbuild)
-[![PyPI Version](https://img.shields.io/pypi/v/xbuild.svg)](https://pypi.python.org/pypi/xbuild)
-[![Maturity](https://img.shields.io/pypi/status/xbuild.svg)](https://pypi.python.org/pypi/xbuild)
-[![BSD License](https://img.shields.io/pypi/l/xbuild.svg)](https://github.com/beeware/xbuild/blob/master/LICENSE)
-[![Discord server](https://img.shields.io/discord/836455665257021440?label=Discord%20Chat&logo=discord&style=plastic)](https://beeware.org/bee/chat/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/xbuild.svg)](https://pypi.python.org/pypi/xbuild) [![PyPI Version](https://img.shields.io/pypi/v/xbuild.svg)](https://pypi.python.org/pypi/xbuild) [![Maturity](https://img.shields.io/pypi/status/xbuild.svg)](https://pypi.python.org/pypi/xbuild) [![BSD License](https://img.shields.io/pypi/l/xbuild.svg)](https://github.com/beeware/xbuild/blob/master/LICENSE) [![Discord server](https://img.shields.io/discord/836455665257021440?label=Discord%20Chat&logo=discord&style=plastic)](https://beeware.org/bee/chat/)
 
 `xbuild` is PEP517 build frontend that has additions and extensions to support cross-compiling wheels for platforms where compilation cannot be performed natively - most notably:
 
-* Android
-* Emscripten (WASM)
-* iOS
+- Android
+- Emscripten (WASM)
+- iOS
 
 ## Usage
 
 To use xbuild, you need:
-* an install of Python for the platform where you will be performing the build (e.g., macOS, Linux or Windows)
-* a distribution of Python that has been compiled for your target platform (e.g., Android, Emscripten or iOS)
+
+- an install of Python for the platform where you will be performing the build (e.g., macOS, Linux or Windows)
+- a distribution of Python that has been compiled for your target platform (e.g., Android, Emscripten or iOS)
 
 ### Build a package
 
 Create a virtual environment for your build platform (i.e., the platform where you will be compiling), and install `xbuild`:
 
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    (venv) $ python -m pip install xbuild
+```console
+$ python3 -m venv venv
+$ source venv/bin/activate
+(venv) $ python -m pip install xbuild
+```
 
 You can then run `xbuild` from the root directory of the project you want to build. You *must* pass in the `--sysconfig` argument, providing the path to the `sysconfig_vars` JSON file for the target platform, or the equivalent `sysconfigdata` python configuration.
 
-    (venv) $ python -m xbuild --sysconfig path/to/_sysconfig_vars__...json
+```console
+(venv) $ python -m xbuild --sysconfig path/to/_sysconfig_vars__...json
+```
 
 This will create an isolated cross-platform virtual environment, and trigger a PEP 517 build in that environment. Any build `requires` will be installed *for the build platform*. For example, if you're running on macOS, building for an ARM64 iPhone simulator, and your project lists `ninja` as a requirement, the *macOS* version of ninja will be installed. This ensures that the binary will be executable during the build.
 
 If, for some reason, you require the *iOS* version of a build requirement to be installed, you can specify `target-requires` in your `build-system` table. For example, to add the iOS version of "target-tool" to your isolated cross-build environment, you might use:
 
-    [build-system]
-    requires = ["setuptools"]
-    target-requires = ["target-tool"]
-    build-backend = "setuptools.build_meta"
+```toml
+[build-system]
+requires = ["setuptools"]
+target-requires = ["target-tool"]
+build-backend = "setuptools.build_meta"
+```
 
 In order for a cross-build to succeed, your environment must be configured appropriately for the platform you're targeting. This means setting `PATH` and other environment variables appropriately.
 
@@ -45,10 +48,10 @@ In order for a cross-build to succeed, your environment must be configured appro
 
 To build an Android wheel, you must:
 
-* Have Android Studio or the Android Command-line Tools installed
-* Have `ANDROID_HOME` configured in your environment
-* Have a Java SDK installed
-* Have `JAVA_HOME` defined in your environment
+- Have Android Studio or the Android Command-line Tools installed
+- Have `ANDROID_HOME` configured in your environment
+- Have a Java SDK installed
+- Have `JAVA_HOME` defined in your environment
 
 #### iOS
 
@@ -56,39 +59,43 @@ You must have Xcode installed, with the iOS SDK added.
 
 It is also strongly advised that you:
 
-* Add the path to the iOS binary shims to your path. These are provided in the `Python.xcframework/ios-arm64/bin` and `Python.xcframework/ios-arm64_x86_64-simulator/bin` folder for the iOS support package that you have downloaded.
+- Add the path to the iOS binary shims to your path. These are provided in the `Python.xcframework/ios-arm64/bin` and `Python.xcframework/ios-arm64_x86_64-simulator/bin` folder for the iOS support package that you have downloaded.
 
-* Clear your path of any other dependencies. It is very easy for macOS ARM64 binaries from Homebrew and other sources to leak into iOS builds if they are present on the path; the safest approach is to set your path so it only contains:
-  - The path for the Python binary (ideally, your virtual environment's `bin` directory)
-  - `/usr/bin`
-  - `/bin`
-  - `/usr/sbin`
-  - `/sbin`
-  - `/Library/Apple/usr/bin`
+- Clear your path of any other dependencies. It is very easy for macOS ARM64 binaries from Homebrew and other sources to leak into iOS builds if they are present on the path; the safest approach is to set your path so it only contains:
+    - The path for the Python binary (ideally, your virtual environment's `bin` directory)
+    - `/usr/bin`
+    - `/bin`
+    - `/usr/sbin`
+    - `/sbin`
+    - `/Library/Apple/usr/bin`
 
 #### Emscripten
 
-TODO
+Coming soon...
 
 ### Creating a cross virtual environment
 
 To explicitly create a cross-platform virtual environment, start by creating a virtual environment for your build platform (i.e., the platform where you will be compiling), then use the `xvenv` script to convert a virtual environment in to a cross environment.
 
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    (venv) $ python -m pip install xbuild
-    (venv) $ python -m xvenv --sysconfig path/to/_sysconfig_vars__...json x-venv
+```console
+$ python3 -m venv venv
+$ source venv/bin/activate
+(venv) $ python -m pip install xbuild
+(venv) $ python -m xvenv --sysconfig path/to/_sysconfig_vars__...json x-venv
+```
 
 If `x-venv` doesn't already exist, `xvenv` will create it first (equivalent to running `python -m venv x-venv`), then convert it into a cross environment. If `x-venv` already exists, it will be converted into a cross-platform environment of type specified by `--sysconfig`.
 
 You can then deactivate the environment that was used to create the cross-platform environment, and activate the cross-platform virtual environment. For example, if `x-venv` was constructed using an iOS simulator sysconfig vars file (`_sysconfig_vars__ios_arm64-iphonesimulator.json`), you would see output like:
 
-    (venv) $ deactivate
-    $ source x-venv/bin/activate
-    (x-venv) $ python -c "import sys; print(sys.platform)"
-    ios
-    (x-venv) $ python -c "import sys; print(sys.implementation._multiarch)"
-    arm64-iphonesimulator
+```console
+(venv) $ deactivate
+$ source x-venv/bin/activate
+(x-venv) $ python -c "import sys; print(sys.platform)"
+ios
+(x-venv) $ python -c "import sys; print(sys.implementation._multiarch)"
+arm64-iphonesimulator
+```
 
 This should now print the platform identifier for the target platform, not your build platform.
 
@@ -96,11 +103,13 @@ You can also configure xvenv with a `_sysconfigdata` Python file (e.g., `_syscon
 
 If you are in the cross-platform environment, and you need to temporarily convert it back to the build platform, you can do so with the `XBUILD_ENV` environment variable. For example, if `x-venv` is an iOS cross-platform environment:
 
-    $ source x-venv/bin/activate
-    (x-venv) $ python -c "import sys; print(sys.platform)"
-    ios
-    (x-venv) $ XBUILD_ENV=off python -c "import sys; print(sys.platform)"
-    darwin
+```console
+$ source x-venv/bin/activate
+(x-venv) $ python -c "import sys; print(sys.platform)"
+ios
+(x-venv) $ XBUILD_ENV=off python -c "import sys; print(sys.platform)"
+darwin
+```
 
 If you have an active cross-platform virtual environment, you can run `xbuild` without providing the `--sysconfig` variable. The configuration of your existing cross virtual environment will copied into the isolated environment for the build. Alternatively, you can also use the `--no-isolation` flag to disable the creation of a isolated cross-platform build environment. This will use your existing cross-platform environment as the build environment.
 
@@ -108,14 +117,16 @@ If you have an active cross-platform virtual environment, you can run `xbuild` w
 
 The cross build environment does not run the target platform binaries on the build platform - it uses binaries for the build platform, but monkey-patches the Python interpreter at startup so that any question asking details about the platform returns details about the target platform. For example, if you create an iOS cross-platform environment on a macOS machine, you'll be using the macOS `python.exe`; but if you ask for `sys.platform`, the answer will be `ios`, not `darwin`.
 
-## Contributing
+## Development
 
 To set up a development environment:
 
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    (venv) $ python -m pip install -U pip
-    (venv) $ python -m pip install -e . --group dev
+```console
+$ python3 -m venv venv
+$ source venv/bin/activate
+(venv) $ python -m pip install -U pip
+(venv) $ python -m pip install -e . --group dev
+```
 
 ## Community
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,36 @@ known-third-party = [
     "build",
 ]
 
+[tool.rumdl]
+flavor = "mkdocs"
+include = ["**/*.md"]
+exclude = ["comment.md", "CODE_OF_CONDUCT.md"]
+respect-gitignore = true
+
+# Disable rules:
+# MD014: Force commands in codeblocks to show output
+disable = ["MD014"]
+
+[tool.rumdl.per-file-ignores]
+# MD002: First heading should be level 1, found level 2; title will be included in the target page
+# MD034: URL without angle brackets or link formatting; triggers on URLs with Jinja variable included
+# MD041: First line in file should be level 1 heading; title will be included in the target page
+"src/beeware_docs_tools/shared_content/en/*.md" = ["MD002", "MD034", "MD041",]
+
+[tool.rumdl.MD013]  # Line length
+line_length = 999999  # Force reflow to paragraph content to remove linebreaks
+reflow = true
+reflow_mode = "normalize"
+
+[tool.rumdl.MD026]  # Remove punctuation at the end of headings
+punctuation = ",;:"
+
+[tool.rumdl.MD033]  # No inline HTML
+allowed_elements = ["nospell",]  # pyspelling inline disable tag
+
+[tool.rumdl.MD061]
+terms = ["TODO"]
+
 [tool.check-wheel-contents]
 toplevel = [
     "xbuild",

--- a/src/xvenv/__main__.py
+++ b/src/xvenv/__main__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import venv
 from argparse import ArgumentParser
 from collections.abc import Sequence
 from pathlib import Path
@@ -80,22 +81,22 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
     )
 
     if not venv_path.exists():
-        _error(f"Native virtual environment {venv_path} does not exist.")
+        venv.create(venv_path, with_pip=True)
+
+    try:
+        description = convert_venv(
+            venv_path,
+            build_details_path=build_details_path,
+            sysconfigdata_path=sysconfigdata_path,
+        )
+    except ValueError as e:
+        _error(e)
+        sys.exit(1)
     else:
-        try:
-            description = convert_venv(
-                venv_path,
-                build_details_path=build_details_path,
-                sysconfigdata_path=sysconfigdata_path,
-            )
-        except ValueError as e:
-            _error(e)
-            sys.exit(1)
-        else:
-            _cprint(
-                "{bold}{green}{}{reset}",
-                f"{args.venv} is now an {description} cross venv.",
-            )
+        _cprint(
+            "{bold}{green}{}{reset}",
+            f"{args.venv} is now an {description} cross venv.",
+        )
 
 
 def entrypoint() -> None:


### PR DESCRIPTION
As a convenience, make `xvenv` behave the same as `venv` - creating the venv if it doesn't already exist. 

Pre-existing "convert venv" behavior continues to exist.

Includes addition of rumdl and some rumdl-related formatting updates, and population of the release notes.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Sonnet 5
